### PR TITLE
Fixing SQL init script importation.

### DIFF
--- a/tasks/initiate_database.yml
+++ b/tasks/initiate_database.yml
@@ -36,6 +36,7 @@
     target: /tmp/{{ item }}
     login_user: root
     login_password: "{{ mysql_root_password }}"
+  with_items: "{{ sql_file_name }}"
   when: 
     - database is defined and create_database
     - import_sql_file


### PR DESCRIPTION
I tried to use this Ansible role to set up and configure mariadb server on Ubuntu and import some SQL files upon database creation. However, I consistently ran into the following error:
`fatal: [localhost]: FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: 'item' is undefined\n\nThe error appears to be in '/root/.ansible/roles/mahdi22.mariadb_install/tasks/initiate_database.yml': line 32, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Import init script to database\n  ^ here\n"}`

I finally had a look at the specified task file "initiate_database.yml" and realized that the `with_items` keyword is missing.